### PR TITLE
Summary report format

### DIFF
--- a/ocldev/oclfleximporter.py
+++ b/ocldev/oclfleximporter.py
@@ -283,7 +283,7 @@ class OclImportResults(object):
         if root_key:
             output = '%s %s for key "%s"' % (process_str, output, root_key)
         else:
-            output = '%s %s of %s -- %s in %s' % (
+            output = '%s %s of %s -- %s in %s secs' % (
                 process_str, total_count, self.total_lines, output, self.elapsed_seconds
             )
 

--- a/ocldev/oclfleximporter.py
+++ b/ocldev/oclfleximporter.py
@@ -283,8 +283,9 @@ class OclImportResults(object):
         if root_key:
             output = '%s %s for key "%s"' % (process_str, output, root_key)
         else:
-            output = '%s %s of %s -- %s' % (
-                process_str, total_count, self.total_lines, output)
+            output = '%s %s of %s -- %s in %s' % (
+                process_str, total_count, self.total_lines, output, self.elapsed_seconds
+            )
 
         return output
 


### PR DESCRIPTION
Currently detailed_summary returns:
`Processed 55 of 55 -- 55 UPDATE (201:19, 200:36)`.

This pull request adds elapsed seconds in summary, so it will now return:
`Processed 55 of 55 -- 55 UPDATE (201:19, 200:36) in 6 secs`